### PR TITLE
Label separation and batch size clairifcation

### DIFF
--- a/harness/calculate_quality.py
+++ b/harness/calculate_quality.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+calculate_quality.py - Quality calculator for ML Inference workload.
+"""
+
+import sys
+from pathlib import Path
+import utils
+from utils import parse_submission_arguments
+
+def main():
+
+    """
+    Usage:  python3 calculate_quality.py  <expected_file>  <result_file> <num_samples>
+    Calculates accuracy by comparing labels line by line.
+    Each file should contain one label per line.
+    Returns accuracy metric and prints results.
+    """
+    __, params, __, __, __, __ = parse_submission_arguments('Generate query for FHE benchmark.')
+
+    expected_file = params.datadir() / "dataset_labels.txt"
+    result_file   = params.iodir() / "quality_result.txt"
+    num_samples   = 10 if params.size == utils.SINGLE else 10000
+
+
+    try:
+        # Read expected labels (one per line)
+        expected_labels = expected_file.read_text().strip().split('\n')
+        expected_labels = [label.strip() for label in expected_labels if label.strip()]
+        
+        # Read result labels (one per line)
+        result_labels = result_file.read_text().strip().split('\n')
+        result_labels = [label.strip() for label in result_labels if label.strip()]
+        
+    except Exception as e:
+        print(f"[harness] failed to read files: {e}")
+        sys.exit(1)
+
+    # Check if we have enough labels in both files
+    if len(expected_labels) < num_samples:
+        print(f"[harness] FAIL - Not enough expected labels: have {len(expected_labels)}, need {num_samples}")
+        sys.exit(1)
+    
+    if len(result_labels) < num_samples:
+        print(f"[harness] FAIL - Not enough result labels: have {len(result_labels)}, need {num_samples}")
+        sys.exit(1)
+
+    # Calculate accuracy for the first num_samples only
+    expected_subset = expected_labels[:num_samples]
+    result_subset = result_labels[:num_samples]
+    
+    correct_predictions = sum(1 for exp, res in zip(expected_subset, result_subset) if exp == res)
+    accuracy = correct_predictions / num_samples 
+
+    print(f"[harness] Accuracy: {accuracy:.4f} ({correct_predictions}/{num_samples} correct)")
+
+    OUT_PATH = params.measuredir() / f"quality.txt"
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(f"{accuracy:.4f}\n({correct_predictions}/{num_samples} correct)\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/calculate_quality.py
+++ b/harness/calculate_quality.py
@@ -11,7 +11,6 @@ from utils import parse_submission_arguments
 def main():
 
     """
-    Usage:  python3 calculate_quality.py  <expected_file>  <result_file> <num_samples>
     Calculates accuracy by comparing labels line by line.
     Each file should contain one label per line.
     Returns accuracy metric and prints results.

--- a/harness/calculate_quality.py
+++ b/harness/calculate_quality.py
@@ -20,8 +20,16 @@ def main():
 
     expected_file = params.datadir() / "dataset_labels.txt"
     result_file   = params.iodir() / "quality_result.txt"
-    num_samples   = 10 if params.size == utils.SINGLE else 10000
-
+    
+    num_samples   = 10 
+    if params.size == utils.SINGLE:
+        num_samples = 10
+    elif params.size == utils.SMALL:
+        num_samples = 100
+    elif params.size == utils.MEDIUM:
+        num_samples = 1000
+    elif params.size == utils.LARGE:
+        num_samples = 10000
 
     try:
         # Read expected labels (one per line)

--- a/harness/cleartext_impl.py
+++ b/harness/cleartext_impl.py
@@ -9,39 +9,12 @@ For each test case:
 from pathlib import Path
 from utils import parse_submission_arguments
 
-def get_first_char_as_int(file_path):
-    """
-    Read the first character from the first line of a file and return it as an integer.
-    
-    Args:
-        file_path (Path): Path to the file
-        
-    Returns:
-        int: First character as integer, or None if file doesn't exist/is empty/not a digit
-    """
-    if file_path.exists():
-        with open(file_path, 'r') as f:
-            first_line = f.readline()
-            if first_line and first_line[0].isdigit():
-                return int(first_line[0])
-            elif first_line:
-                print(f"First character '{first_line[0]}' is not a digit")
-                return None
-            else:
-                print("File is empty")
-                return None
-    else:
-        print(f"File {file_path} does not exist")
-        return None
-
 def main():
     __, params, __, __, __, __ = parse_submission_arguments('Generate dataset for FHE benchmark.')
-    INPUT_PATH = params.dataset_intermediate_dir() / f"plain_input.bin"
-    # Get reference result
-    result = get_first_char_as_int(INPUT_PATH)
-    if result is None:
-        print(f"Failed to read a valid integer from {INPUT_PATH}. Exiting.")
-        return
+    INPUT_PATH = params.dataset_intermediate_dir() / f"plain_output.bin"
+    
+    # Get reference result by reading from INPUT_PATH
+    result = INPUT_PATH.read_text(encoding="utf-8").strip()
 
     # Write to expected.txt (overwrites if it already exists)
     OUT_PATH = params.dataset_intermediate_dir() / f"expected.txt"

--- a/harness/generate_input.py
+++ b/harness/generate_input.py
@@ -28,9 +28,11 @@ def main():
     Generate random value representing the query in the workload.
     """
     __, params, seed, __, __, __ = parse_submission_arguments('Generate query for FHE benchmark.')
-    DATASET_PATH = params.datadir() / f"dataset.txt"
+    DATASET_PIXEL_PATH = params.datadir() / f"dataset_pixels.txt"
+    DATASET_LABEL_PATH = params.datadir() / f"dataset_labels.txt"
 
     DATASET_INPUT_PATH = params.dataset_intermediate_dir() / f"plain_input.bin"
+    DATASET_OUTPUT_PATH = params.dataset_intermediate_dir() / f"plain_output.bin"
     DATASET_INPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -39,19 +41,30 @@ def main():
         np.random.seed(seed)
     
     # Pick a random query from the dataset.
-    num_lines = count_lines_in_file(DATASET_PATH)
+    num_lines = count_lines_in_file(DATASET_PIXEL_PATH)
     random_line = np.random.randint(1, num_lines + 1)
-    if DATASET_PATH.exists():
-        with open(DATASET_PATH, 'r') as f:
+    if DATASET_PIXEL_PATH.exists():
+        with open(DATASET_PIXEL_PATH, 'r') as f:
             for i, line in enumerate(f):
                 if i == random_line - 1:
                     break
     else:
-        print(f"Dataset file {DATASET_PATH} does not exist.")
-    
-    # Write the input to a file
+        print(f"Dataset file {DATASET_PIXEL_PATH} does not exist.")
+     # Write the input to a file
     with open(DATASET_INPUT_PATH, 'w') as f:
         # Assuming the line contains space-separated values, we can write it directly
+        f.write(line.strip())
+
+    if DATASET_LABEL_PATH.exists():
+        with open(DATASET_LABEL_PATH, 'r') as f:
+            for i, line in enumerate(f):
+                if i == random_line - 1:
+                    break
+    else:
+        print(f"Dataset file {DATASET_LABEL_PATH} does not exist.")
+
+    # Write the label to a file
+    with open(DATASET_OUTPUT_PATH, 'w') as f:
         f.write(line.strip())
 
 

--- a/harness/mnist/mnist.py
+++ b/harness/mnist/mnist.py
@@ -159,14 +159,14 @@ def test_model(model, test_loader, device):
     print(f'Accuracy on test data: {accuracy:.2f}%')
     return accuracy
 
-# Function to export test data to file.
+# Function to export test data to separate files.
 def export_test_data(data_dir='./data', output_file='mnist_test.txt', num_samples=-1):
     """
-    Export MNIST test dataset to a text file.
+    Export MNIST test dataset to separate label and pixel files.
     
     Args:
         data_dir (str): Directory to load dataset from
-        output_file (str): Output file path
+        output_file (str): Base output file path (will create .labels and .pixels files)
         num_samples (int): Number of samples to export (-1 for all)
     """
     transform = transforms.Compose([
@@ -178,7 +178,12 @@ def export_test_data(data_dir='./data', output_file='mnist_test.txt', num_sample
     total_samples = len(test_dataset)
     samples_to_export = total_samples if num_samples == -1 else min(num_samples, total_samples)
     
-    with open(output_file, 'w') as f:
+    # Create separate file names for labels and pixels
+    base_name = str(output_file).rsplit('.', 1)[0] if '.' in str(output_file) else str(output_file)
+    labels_file = f"{base_name}_labels.txt"
+    pixels_file = f"{base_name}_pixels.txt"
+    
+    with open(labels_file, 'w') as label_f, open(pixels_file, 'w') as pixel_f:
         for i, (image, label) in enumerate(test_dataset):
             if i >= samples_to_export:
                 break
@@ -186,11 +191,12 @@ def export_test_data(data_dir='./data', output_file='mnist_test.txt', num_sample
             # Flatten the image to 784 dimensions (28x28)
             flattened_image = image.view(-1).numpy()
             
-            # Write label first, then the 784 pixel values
-            f.write(f"{label}")
-            for pixel in flattened_image:
-                f.write(f" {pixel:.6f}")
-            f.write("\n")
+            # Write label to labels file
+            label_f.write(f"{label}\n")
+            
+            # Write pixel values to pixels file
+            pixel_values = " ".join(f"{pixel:.6f}" for pixel in flattened_image)
+            pixel_f.write(f"{pixel_values}\n")
 
 
 def main(argv):

--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -63,12 +63,14 @@ def main():
     utils.log_step(3, "Server: (Encrypted) model preprocessing")
 
     if quality_check:
-        # Run the quality check
-        # This is a server-side step, so we run it in the server directory
+        # 4. Run the quality check for encrypted inference.
         cmd = [exec_dir/"server_encrypted_model_quality", str(size)]
         subprocess.run(cmd, check=True)
         utils.log_step(4, "Server: Encrypted inference model quality check")
-        print("         [harness] Wrote quality result to: ", params.iodir() / "quality.txt")
+
+        # 5. Calculate and save accuracy.
+        subprocess.run(["python3", harness_dir/"calculate_quality.py",
+            str(size)], check=True)
     else:
         # Run steps 4-10 multiple times if requested
         for run in range(num_runs):

--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -21,8 +21,10 @@ def main():
     # Get the arguments
     size, params, seed, num_runs, clrtxt, quality_check = utils.parse_submission_arguments('Run ML Inference FHE benchmark.')
     if size > utils.SINGLE and not quality_check:
-        print(f"Batch size is supported for quality check.")
+        print(f"Currently only single inference is supported for measuring latency.")
         sys.exit(1)
+    if size < utils.LARGE and quality_check:
+        print(f"Use LARGE to measure quality across the entire dataset")
     test = instance_name(size)
     print(f"\n[harness] Running submission for {test} inference")
 

--- a/submission/include/mlp_encryption_utils.h
+++ b/submission/include/mlp_encryption_utils.h
@@ -17,14 +17,15 @@ using PublicKeyT = PublicKey<DCRTPoly>;
 #define NORMALIZED_DIM 1024
 
 struct Sample {
-  int label;
   float image[NORMALIZED_DIM];
 };
 
 ConstCiphertext<DCRTPoly> encrypt_input(CryptoContext<DCRTPoly> cc, std::vector<float> input, PublicKey<DCRTPoly> pk);
 std::vector<float> mlp_decrypt(CryptoContextT v11343, CiphertextT v11344, PrivateKeyT v11345);
 PublicKey<DCRTPoly> read_public_key(const InstanceParams& prms);
+PrivateKey<DCRTPoly> read_secret_key(const InstanceParams& prms);
 CryptoContext<DCRTPoly> read_crypto_context(const InstanceParams& prms);
+void read_eval_keys(const InstanceParams& prms, CryptoContextT cc);
 void load_dataset(std::vector<Sample> &dataset, const char *filename);
 int argmax(float *A, int N);
 

--- a/submission/src/server_encrypted_compute.cpp
+++ b/submission/src/server_encrypted_compute.cpp
@@ -2,6 +2,7 @@
 #include "utils.h"
 #include "params.h"
 #include "mlp_openfhe.h"
+#include "mlp_encryption_utils.h"
 #include <chrono>
 
 using namespace lbcrypto;
@@ -17,31 +18,10 @@ int main(int argc, char* argv[]){
     auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
     InstanceParams prms(size);
 
-    CryptoContext<DCRTPoly> cc;
-
-    if (!Serial::DeserializeFromFile(prms.pubkeydir()/"cc.bin", cc,
-                                    SerType::BINARY)) {
-        throw std::runtime_error("Failed to get CryptoContext from  " + prms.pubkeydir().string());
-    }
-    PublicKey<DCRTPoly> pk;
-    if (!Serial::DeserializeFromFile(prms.pubkeydir()/"pk.bin", pk,
-                                    SerType::BINARY)) {
-        throw std::runtime_error("Failed to get public key from  " + prms.pubkeydir().string());
-    }
-
-    std::ifstream emult_file(prms.pubkeydir()/"mk.bin", std::ios::in | std::ios::binary);
-    if (!emult_file.is_open() ||
-        !cc->DeserializeEvalMultKey(emult_file, SerType::BINARY)) {
-      throw std::runtime_error(
-        "Failed to get re-linearization key from " +prms.pubkeydir().string());
-    }
-
-    std::ifstream erot_file(prms.pubkeydir()/"rk.bin", std::ios::in | std::ios::binary);
-    if (!erot_file.is_open() ||
-        !cc->DeserializeEvalAutomorphismKey(erot_file, SerType::BINARY)) {
-      throw std::runtime_error(
-        "Failed to get rotation keys from " + prms.pubkeydir().string());
-    }
+    CryptoContext<DCRTPoly> cc = read_crypto_context(prms);
+    read_eval_keys(prms, cc);
+    PublicKey<DCRTPoly> pk = read_public_key(prms);
+    
     std::cout << "         [server] Loading keys" << std::endl;
 
     Ciphertext<DCRTPoly> ctxt;

--- a/submission/src/server_encrypted_model_quality.cpp
+++ b/submission/src/server_encrypted_model_quality.cpp
@@ -20,6 +20,10 @@ int main(int argc, char* argv[]){
     int batch_size = 10;
     if (size == 0) {
         batch_size = 10; // Run on 10 samples for SINGLE instance
+    } else if (size == 1) {
+        batch_size = 100; // Run on 100 samples for SMALL instance
+    } else if (size == 2) {
+        batch_size = 1000; // Run on 1000 samples for MEDIUM instance
     } else {
         batch_size = 10000; // Run on 10000 samples for LARGE instance
     }


### PR DESCRIPTION
- Create dataset_labels.txt and dataset_pixels.txt as two separate files so that submitter code does not have access to labels.
- Clarify that only single inference is measured for latency 
- Clarify quality measurements is better measured on the entire dataset to get a comprehensive aulity metric.