### PR TITLE
Fix  LD_LIBRARY_PATH issue

### DIFF
--- a/submission/CMakeLists.txt
+++ b/submission/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
 endif ()
 
 set( CMAKE_CXX_FLAGS "${OpenFHE_CXX_FLAGS} -Werror")
+add_link_options(-Wl,--no-as-needed)
 
 
 # --------------------------------------------------------------------
@@ -96,6 +97,7 @@ add_executable( server_preprocess_model src/server_preprocess_model.cpp )
 
 add_executable( server_encrypted_compute src/server_encrypted_compute.cpp )
 target_link_libraries( server_encrypted_compute mlp_openfhe )
+target_link_libraries( server_encrypted_compute mlp_encryption_utils )
 
 add_executable( server_encrypted_model_quality src/server_encrypted_model_quality.cpp )
 target_link_libraries( server_encrypted_model_quality mlp_openfhe )


### PR DESCRIPTION
Update CMakeLists.txt with ```add_link_options(-Wl,--no-as-needed)``` to no longer need to manually export LD_LIBRARY_PATH