### PR TITLE
Add reference model quality in addition to encrypted model quality.

### DIFF
--- a/harness/calculate_quality.py
+++ b/harness/calculate_quality.py
@@ -17,34 +17,41 @@ def main():
     """
     __, params, __, __, __, __ = parse_submission_arguments('Generate query for FHE benchmark.')
 
-    expected_file = params.dataset_intermediate_dir() / "test_labels.txt"
+    test_set_label = params.dataset_intermediate_dir() / "test_labels.txt"
+    reference_model_predictions = params.dataset_intermediate_dir() / "reference_model_predictions.txt"
     result_file   = params.iodir() / "result_labels.txt"
 
     try:
         # Read expected labels (one per line)
-        expected_labels = expected_file.read_text().strip().split('\n')
+        expected_labels = test_set_label.read_text().strip().split('\n')
         expected_labels = [label.strip() for label in expected_labels if label.strip()]
         
         # Read result labels (one per line)
         result_labels = result_file.read_text().strip().split('\n')
         result_labels = [label.strip() for label in result_labels if label.strip()]
-        
+
+        reference_model_preds = reference_model_predictions.read_text().strip().split('\n')
+        reference_model_preds = [label.strip() for label in reference_model_preds if label.strip()]
+
     except Exception as e:
         print(f"[harness] failed to read files: {e}")
         sys.exit(1)
 
     num_samples = len(expected_labels)
 
-    correct_predictions = sum(1 for exp, res in zip(expected_labels, result_labels) if exp == res)
-    accuracy = correct_predictions / num_samples
+    correct_encrypted_predictions = sum(1 for exp, res in zip(expected_labels, result_labels) if exp == res)
+    encrypted_model_accuracy = correct_encrypted_predictions / num_samples
+    print(f"[harness] Encrypted Model Accuracy: {encrypted_model_accuracy:.4f} ({correct_encrypted_predictions}/{num_samples} correct)")
+    utils.log_quality(correct_encrypted_predictions, num_samples, "encrypted model quality")
 
-    print(f"[harness] Accuracy: {accuracy:.4f} ({correct_predictions}/{num_samples} correct)")
-
-    quality_json = {"accuracy": accuracy, "correct": correct_predictions, "total": num_samples}
+    correct_ref_model_predictions = sum(1 for exp, res in zip(expected_labels, reference_model_preds) if exp == res)
+    reference_model_accuracy = correct_ref_model_predictions / num_samples
+    print(f"[harness] Reference Model Accuracy: {reference_model_accuracy:.4f} ({correct_ref_model_predictions}/{num_samples} correct)")
+    utils.log_quality(correct_ref_model_predictions, num_samples, "reference model quality")
 
     OUT_PATH = params.measuredir() / f"encrypted_model_quality.json"
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    utils.save_quality(OUT_PATH, correct_predictions, num_samples, "encrypted model quality")
+    utils.save_quality(OUT_PATH)
 
 
 if __name__ == "__main__":

--- a/harness/cleartext_impl.py
+++ b/harness/cleartext_impl.py
@@ -2,23 +2,28 @@
 """
 Cleartext reference for the “ML Inference” workload.
 For each test case:
-    - Reads the plain_input.bin file from the dataset intermediate directory
-    - Writes the result to expected_XXX.txt for each test case (# datasets/expected.txt)
+    - Reads the input pixels from the dataset intermediate directory
+    - Writes the predicted labels to output_labels path.
 """
 
+import sys
 from pathlib import Path
 from utils import parse_submission_arguments
+from mnist import mnist
 
 def main():
-    __, params, __, __, __, __ = parse_submission_arguments('Generate dataset for FHE benchmark.')
-    INPUT_PATH = params.dataset_intermediate_dir() / f"plain_output.bin"
-    
-    # Get reference result by reading from INPUT_PATH
-    result = INPUT_PATH.read_text(encoding="utf-8").strip()
+    """
+    Usage:  python3 cleartext_impl.py  <input_pixels_path>  <output_labels_path>
+    """
 
-    # Write to expected.txt (overwrites if it already exists)
-    OUT_PATH = params.dataset_intermediate_dir() / f"expected.txt"
-    OUT_PATH.write_text(f"{result}\n", encoding="utf-8")
+    if len(sys.argv) != 3:
+        sys.exit("Usage: cleartext_impl.py <input_pixels_path> <output_labels_path>")
+
+    INPUT_PATH = Path(sys.argv[1])
+    OUTPUT_PATH = Path(sys.argv[2])
+    model_path = "harness/mnist/mnist_ffnn_model.pth"
+
+    mnist.run_predict(model_path=model_path, pixels_file=INPUT_PATH, predictions_file=OUTPUT_PATH)
 
 if __name__ == "__main__":
     main()

--- a/harness/mnist/test.py
+++ b/harness/mnist/test.py
@@ -1,5 +1,7 @@
 
+import os
 import torch
+import model as simple_ffn
 
 def test_model(model, test_loader, device):
     model.eval() # Set model to evaluation mode
@@ -15,3 +17,59 @@ def test_model(model, test_loader, device):
     accuracy = 100 * correct / total
     print(f'Accuracy on test data: {accuracy:.2f}%')
     return accuracy
+
+
+def predict(pixels_file, model_path="mnist_ffnn_model.pth", predictions_file='predictions.txt', device='cpu'):
+    """
+    Load a trained model and make predictions on pixel data from a file.
+    
+    Args:
+        pixels_file (str): Path to file containing pixel data (one sample per line, 784 values per line)
+        model_path (str): Path to the trained model file
+        predictions_file (str): Path to save the predictions
+        device (str): Device to run inference on ('cpu' or 'cuda')
+    
+    Returns:
+        list: List of predicted class labels
+    """
+    # Set device
+    device = torch.device(device)
+    
+    # Load the trained model
+    model = simple_ffn.SimpleFFNN().to(device)
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"Model file not found: {model_path}")
+    
+    model.load_state_dict(torch.load(model_path, map_location=device))
+    model.eval()  # Set model to evaluation mode
+    
+    # Read pixel data from file
+    pixel_data = []
+    with open(pixels_file, 'r') as f:
+        for line in f:
+            # Parse the line and convert to float values
+            pixel_values = [float(x) for x in line.strip().split()]
+            if len(pixel_values) != 784:
+                raise ValueError(f"Each line must contain exactly 784 pixel values, got {len(pixel_values)}")
+            pixel_data.append(pixel_values)
+    
+    # Convert to tensor and apply normalization (same as training)
+    # The pixel values should already be normalized (0-1), but we need to apply MNIST normalization
+    pixel_tensor = torch.tensor(pixel_data, dtype=torch.float32).to(device)
+    # Apply MNIST normalization: (pixel - mean) / std
+    pixel_tensor = (pixel_tensor - 0.1307) / 0.3081
+    
+    predictions = []
+    
+    # Make predictions
+    with torch.no_grad():
+        outputs = model(pixel_tensor)
+        _, predicted = torch.max(outputs, 1)
+        predictions = predicted.cpu().numpy().tolist()
+    
+    # Save predictions to file
+    with open(predictions_file, 'w') as f:
+        for pred in predictions:
+            f.write(f"{pred}\n")
+    
+    return predictions

--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -100,15 +100,8 @@ def main():
         subprocess.run([exec_dir/"client_postprocess", str(size)], check=True)
         utils.log_step(9, "Client: Result postprocessing")
 
-        # 10.1 Run the cleartext computation in cleartext_impl.py
-        # If the cleartext computation takes too long, compute it once for a given state and skip this step.
-        # One can store the results for multiple runs; currently, storing expected.txt works only with num_runs = 1.
-        if clrtxt is None:
-            subprocess.run(["python3", harness_dir/"cleartext_impl.py", str(size)], check=True)
-            print("         [harness] Wrote expected result to: ", params.dataset_intermediate_dir() / "expected.txt")
-
-        # 10.2 Verify the result
-        expected_file = params.dataset_intermediate_dir() / "expected.txt"
+        # 10 Verify the result
+        expected_file = params.dataset_intermediate_dir() / "plain_output.bin"
         result_file = io_dir / "result.txt"
 
         if not result_file.exists():
@@ -139,12 +132,18 @@ def main():
         subprocess.run(cmd, check=True)
         utils.log_step(12.1, "Harness: Input generation for Encrypted Model Quality")
 
-        # 12.2. Run the quality check for encrypted inference.
+        # 12.2 Run the cleartext computation in cleartext_impl.py
+        test_pixels = params.dataset_intermediate_dir() / f"test_pixels.txt"
+        reference_model_predictions = params.dataset_intermediate_dir() / f"reference_model_predictions.txt"
+        subprocess.run(["python3", harness_dir/"cleartext_impl.py", str(test_pixels), str(reference_model_predictions)], check=True)
+        print("         [harness] Wrote reference model predictions to: ", reference_model_predictions)
+
+        # 12.3. Run the quality check for encrypted inference.
         cmd = [exec_dir/"server_encrypted_model_quality", str(size)]
         subprocess.run(cmd, check=True)
-        utils.log_step(12.2, "Server: Encrypted inference model quality check")
+        utils.log_step(12.3, "Server: Encrypted inference model quality check")
 
-        # 12.3. Calculate and save accuracy.
+        # 12.4. Calculate and save accuracy.
         subprocess.run(["python3", harness_dir/"calculate_quality.py",
             str(size)], check=True)
 

--- a/harness/utils.py
+++ b/harness/utils.py
@@ -19,6 +19,8 @@ _timestamps = {}
 _timestampsStr = {}
 # Global variable to store measured sizes
 _bandwidth = {}
+# Global variable to store model quality metrics
+_model_quality = {}
 
 def parse_submission_arguments(workload: str) -> Tuple[int, InstanceParams, int, int, int, bool]:
     """
@@ -132,11 +134,14 @@ def save_run(path: Path):
 
     print("[total latency]", f"{round(sum(_timestamps.values()), 4)}s")
 
-def save_quality(path: Path, correct_predictions, total_samples, tag):
-    json.dump({
-        tag : {
-            "correct_predictions": correct_predictions,
-            "total_samples": total_samples,
-            "accuracy": correct_predictions / total_samples if total_samples > 0 else 0
-        }
-    }, open(path,"w"), indent=2)
+def log_quality(correct_predictions, total_samples, tag):
+    global _model_quality
+    _model_quality[tag] = {
+        "correct_predictions": correct_predictions,
+        "total_samples": total_samples,
+        "accuracy": correct_predictions / total_samples if total_samples > 0 else 0
+    }
+
+def save_quality(path: Path):
+    global _model_quality
+    json.dump({"mnist_model_quality" : _model_quality}, open(path,"w"), indent=2)


### PR DESCRIPTION
The quality metrics now log:

- encrypted model quality
- reference model quality (the model is trained on the fly if its not found in the harness/mnist directory)

both of the above are measured against the ground truth labels.